### PR TITLE
Add getRaw() instance method to return unboxed values

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ $obj->books[1]->title;    // "Pride and Prejudice"
 $obj->books[0]->missing;  // throws InvalidPropertyException
 ```
 
+#### getRaw($key, $default = null)
+
+When a value fetched via `get('some.key')` is an array, it is boxed into an instance of `ArrayObject` .
+The `getRaw()` method, however, does not perform any 'boxing' on the returned value.
+
+The `get()` method allows you to fetch the value of a property, and receive a default if the value does not exist. It also supports depth which is indicated with a `.`:
+
+```php
+$obj->get('books');            // ArrayObject
+$obj->getRaw('books');         // (array)
+$obj->get('books.0.title');    // "1984"
+$obj->getRaw('books.0.title'); // "1984"
+```
+
 #### set($key, $value, $onlyIfExists = false)
 
 The `set()` method allows you to set a property using dot notation. It will automatically create the 

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -244,6 +244,7 @@ class ArrayObject implements ArrayObjectInterface, \ArrayAccess, \Countable, \It
     }
 
     /**
+     * Returns the value for a given key.
      * @param string $key
      * @param mixed  $default
      *
@@ -256,7 +257,24 @@ class ArrayObject implements ArrayObjectInterface, \ArrayAccess, \Countable, \It
             return $default;
         }
 
-        return $this->box($result);
+        return $this->box($this->getRaw($key, $default));
+    }
+
+    /**
+     * Returns the un-boxed (raw) value for the given key.
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function getRaw($key, $default = null)
+    {
+        $result = ArrayUtility::dotRead($this->data, $this->getNormalizedKey($key));
+        if ($result === null) {
+            return $default;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/ArrayObjectTest.php
+++ b/tests/ArrayObjectTest.php
@@ -1146,4 +1146,19 @@ class ArrayObjectTest extends TestCase
         $this->assertTrue(isset($book->id));
         $this->assertFalse(isset($book->missing_field));
     }
+
+    public function test_can_get_unboxed_value()
+    {
+        $foo = ArrayObject::fromArray([
+            'foo' => 'bar',
+        ])->getRaw('foo');
+        $this->assertEquals('bar', $foo);
+
+        $foo = ArrayObject::fromArray([
+            'foo' => [
+                'bar',
+            ],
+        ])->getRaw('foo');
+        $this->assertEquals(['bar'], $foo);
+    }
 }


### PR DESCRIPTION
This PR adds a getRaw() instance method which does not box array values.
Refer to Issue #9 for details