### PR TITLE
[CRM-14077] Lift PHP cap to <8.4 and add 8.3 to CI

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.4", "8.0", "8.1", "8.2"]
+        php: ["7.4", "8.0", "8.1", "8.2", "8.3"]
         composer-version: [prefer-lowest, prefer-stable]
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php" : ">=7.4 <8.3",
+    "php" : ">=7.4 <8.5",
     "rexlabs/utility-belt": "^4.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php" : ">=7.4 <8.5",
+    "php" : ">=7.4 <8.4",
     "rexlabs/utility-belt": "^4.0"
   },
   "require-dev": {


### PR DESCRIPTION
## Feature overview/Issue description

Part of the wings-api PHP 7.4 → 8.3 upgrade ([CRM-14074](https://rexsoftware.atlassian.net/browse/CRM-14074), deps slice [CRM-14077](https://rexsoftware.atlassian.net/browse/CRM-14077) group 5): this package's `<8.3` PHP cap is one of the last composer-level blockers for running wings-api on 8.3.

## Summary of changes

* `composer.json`: PHP constraint `>=7.4 <8.3` → `>=7.4 <8.4`
* CI: PHP 8.3 added to the test matrix (where a matrix exists)

Per the epic's design (D6): constraint-lift + 8.3 CI only — code changes happen only if this package's own 8.3 CI fails.

## Blockers

* After merge, please **tag a release** — wings-api consumes all group-5 lifts in one lock-bump PR once every tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
